### PR TITLE
Source UI code review

### DIFF
--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -15,9 +15,6 @@ const (
 	OdigosInstrumentationLabel   = "odigos-instrumentation"
 	InstrumentationEnabled       = "enabled"
 	InstrumentationDisabled      = "disabled"
-	OdigosNamespaceAnnotation    = "odigos.io/workload-namespace"
-	OdigosWorkloadKindAnnotation = "odigos.io/workload-kind"
-	OdigosWorkloadNameAnnotation = "odigos.io/workload-name"
 	OdigosReportedNameAnnotation = "odigos.io/reported-name"
 	RolloutTriggerAnnotation     = "rollout-trigger"
 

--- a/frontend/services/sources.go
+++ b/frontend/services/sources.go
@@ -11,6 +11,7 @@ import (
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/client"
+	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -269,9 +270,9 @@ func updateAnnotations(annotations map[string]string, reportedName string) map[s
 func GetSourceCRD(ctx context.Context, nsName string, workloadName string, workloadKind WorkloadKind) (*v1alpha1.Source, error) {
 	list, err := kube.DefaultClient.OdigosClient.Sources(nsName).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{
-			consts.OdigosNamespaceAnnotation:    nsName,
-			consts.OdigosWorkloadNameAnnotation: workloadName,
-			consts.OdigosWorkloadKindAnnotation: string(workloadKind),
+			k8sconsts.WorkloadNamespaceLabel: nsName,
+			k8sconsts.WorkloadNameLabel:      workloadName,
+			k8sconsts.WorkloadKindLabel:      string(workloadKind),
 		}).String(),
 	})
 

--- a/frontend/services/sources.go
+++ b/frontend/services/sources.go
@@ -286,10 +286,7 @@ func GetSourceCRD(ctx context.Context, nsName string, workloadName string, workl
 		return nil, fmt.Errorf(`expected to get 1 source "%s", got %d`, workloadName, len(list.Items))
 	}
 
-	crdName := list.Items[0].Name
-	crd, err := kube.DefaultClient.OdigosClient.Sources(nsName).Get(ctx, crdName, metav1.GetOptions{})
-
-	return crd, err
+	return &list.Items[0], err
 }
 
 func createSourceCRD(ctx context.Context, nsName string, workloadName string, workloadKind WorkloadKind) error {


### PR DESCRIPTION
This pull request includes changes to the `common/consts/consts.go` and `frontend/services/sources.go` files to update annotation constants and simplify the retrieval of Source CRDs. The most important changes include removing old annotation constants, updating import statements, and modifying functions to use new annotation labels.

Updates to annotation constants:

* [`common/consts/consts.go`](diffhunk://#diff-179a19de0058edabb08618c747a6bf22f25d8408fdeeeac6b888c9089c5c139fL18-L20): Removed old annotation constants `OdigosNamespaceAnnotation`, `OdigosWorkloadKindAnnotation`, and `OdigosWorkloadNameAnnotation`.

Import statement updates:

* [`frontend/services/sources.go`](diffhunk://#diff-d8f62b6675961fc4e307e4fd622a59132ddc730b6e701ae1bc43dd1695f969a7R14): Added import for `k8sconsts` from `k8sutils/pkg/consts`.

Function modifications:

* [`frontend/services/sources.go`](diffhunk://#diff-d8f62b6675961fc4e307e4fd622a59132ddc730b6e701ae1bc43dd1695f969a7L272-R275): Updated `GetSourceCRD` function to use new annotation labels `WorkloadNamespaceLabel`, `WorkloadNameLabel`, and `WorkloadKindLabel` from `k8sconsts`.
* [`frontend/services/sources.go`](diffhunk://#diff-d8f62b6675961fc4e307e4fd622a59132ddc730b6e701ae1bc43dd1695f969a7L288-R289): Simplified `GetSourceCRD` function to return the first item from the list directly.