### PR TITLE
fix: remove unused parameter from GetNamespace query

### DIFF
--- a/frontend/webapp/graphql/queries/compute-platform.ts
+++ b/frontend/webapp/graphql/queries/compute-platform.ts
@@ -19,7 +19,7 @@ export const GET_COMPUTE_PLATFORM = gql`
 `;
 
 export const GET_NAMESPACE = gql`
-  query GetNamespace($namespaceName: String!, $instrumentationLabeled: Boolean) {
+  query GetNamespace($namespaceName: String!) {
     computePlatform {
       k8sActualNamespace(name: $namespaceName) {
         name


### PR DESCRIPTION
This pull request includes a change to the `GET_NAMESPACE` GraphQL query in the `compute-platform.ts` file. The change removes the `instrumentationLabeled` parameter from the query.

* [`frontend/webapp/graphql/queries/compute-platform.ts`](diffhunk://#diff-31f9118ffb7e3400a45302bd5f30d621f58adaf33d086beb183bd302b980c521L22-R22): Removed the `instrumentationLabeled` parameter from the `GetNamespace` query.